### PR TITLE
Compatible with the Octotree extension

### DIFF
--- a/github-mod.css
+++ b/github-mod.css
@@ -109,7 +109,7 @@
     .header {
         position: fixed;
         width: 100%;
-        z-index: 10000;
+        z-index: 90;
         top: 0;
     }
     body {


### PR DESCRIPTION
[Octotree](https://github.com/buunguyen/octotree) is a browser extension to display GitHub code in tree format. [The z-index value of Octotree's sidebar is 91](https://github.com/buunguyen/octotree/blob/master/src/octotree.less#L15), to be compatible with it, I change the z-index value to 90, so the sidebar can display.

good stylish style! :heart: