### PR TITLE
Fix excessive white space in header

### DIFF
--- a/github-mod.css
+++ b/github-mod.css
@@ -228,6 +228,7 @@
     }
     .repohead.experiment-repo-nav {
         background-color: inherit;
+        padding-top: 0;
     }
     .pagehead ul.pagehead-actions {
         z-index: 5;

--- a/github-mod.css
+++ b/github-mod.css
@@ -228,7 +228,6 @@
     }
     .repohead.experiment-repo-nav {
         background-color: inherit;
-        padding-top: 0;
     }
     .pagehead ul.pagehead-actions {
         z-index: 5;
@@ -246,6 +245,9 @@
 @-moz-document regexp("https?://github.com/.*") {
     body:not(.session-authentication) {
         margin-top: 73px;
+    }
+    .repohead.experiment-repo-nav {
+        padding-top: 0;
     }
 }
 @-moz-document regexp("https?://gist.github.com/.*") {


### PR DESCRIPTION
The repo name was pushed down too far:

![image](https://cloud.githubusercontent.com/assets/10372616/18227835/fa553594-71ff-11e6-8abc-f9255c8a1f4c.png)
Fixed to this:

![image](https://cloud.githubusercontent.com/assets/10372616/18227836/0abb04ae-7200-11e6-9aa1-c5de01b123ea.png)

Love the style!